### PR TITLE
Set AllowAllArgumentsOnNextLine to true

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -33,7 +33,7 @@ AlignOperands: DontAlign
 AlignTrailingComments:
   Kind: Never  # MARK: Adjustable
   OverEmptyLines: 0
-AllowAllArgumentsOnNextLine: false
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false

--- a/clang_format_black.py
+++ b/clang_format_black.py
@@ -37,7 +37,7 @@ AlignOperands: DontAlign
 AlignTrailingComments:
   Kind: {align_trailing_comments}
   OverEmptyLines: 0
-AllowAllArgumentsOnNextLine: false
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
 AllowShortCaseLabelsOnASingleLine: false


### PR DESCRIPTION
Because otherwise clang-format will break `.` and `->`, which is worse.